### PR TITLE
Adding a dark theme to the footer

### DIFF
--- a/packages/ui/components/Footer.tsx
+++ b/packages/ui/components/Footer.tsx
@@ -1,10 +1,13 @@
 import styles from '../styles/Footer.module.css';
 import Link from 'next/link';
 import DarkModeSwitch from "./DarkModeSwitch";
+import { useContext } from "react";
+import { ThemeContext } from "./Layout";
 
 export default function Footer() {
+  const { theme } = useContext(ThemeContext);
   return (
-    <footer>
+    <footer className={theme === "light" ? styles.light : styles.dark}>
       <div className={styles.footer}>
         <div className={styles.logo}>
           <Link href="/" passHref={true}>

--- a/packages/ui/components/Layout.jsx
+++ b/packages/ui/components/Layout.jsx
@@ -10,7 +10,7 @@ const Layout = ({ children }) => {
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>
-      <div className={theme === "light" ? styles.light : styles.dark}>
+      <div>
         <NavBar />
         {children}
         <Footer />

--- a/packages/ui/components/Layout.tsx
+++ b/packages/ui/components/Layout.tsx
@@ -1,9 +1,10 @@
-import NavBar from './NavBar/NavBar';
-import Footer from './Footer';
-import styles from "../styles/Theme.module.css";
+import NavBar from "./NavBar/NavBar";
+import Footer from "./Footer";
 import { useState, createContext } from "react";
 
-export const ThemeContext = createContext({});
+export const ThemeContext = createContext(
+  {} as { theme: string; setTheme: any }
+);
 
 const Layout = ({ children }) => {
   const [theme, setTheme] = useState("light");

--- a/packages/ui/components/NavBar/NavLinks.jsx
+++ b/packages/ui/components/NavBar/NavLinks.jsx
@@ -7,7 +7,12 @@ const NavLinks = (props) => {
       <Link href="/cycles">
         <a onClick={() => props.isMobile && props.closeMobileMenu()}>
           {props.isMobile && (
-            <img src="/LinkImages/cycles.svg" height="18px" width="18px" />
+            <img
+              src="/LinkImages/cycles.svg"
+              height="18px"
+              width="18px"
+              alt="Cycles"
+            />
           )}
           CYCLES
         </a>
@@ -15,7 +20,12 @@ const NavLinks = (props) => {
       <Link href="/docs">
         <a onClick={() => props.isMobile && props.closeMobileMenu()}>
           {props.isMobile && (
-            <img src="/LinkImages/docs.svg" height="18px" width="18px" />
+            <img
+              src="/LinkImages/docs.svg"
+              height="18px"
+              width="18px"
+              alt="Docs"
+            />
           )}
           DOCS
         </a>
@@ -23,7 +33,12 @@ const NavLinks = (props) => {
       <Link href="/security">
         <a onClick={() => props.isMobile && props.closeMobileMenu()}>
           {props.isMobile && (
-            <img src="/LinkImages/security.svg" height="18px" width="18px" />
+            <img
+              src="/LinkImages/security.svg"
+              height="18px"
+              width="18px"
+              alt="Security"
+            />
           )}
           SECURITY
         </a>
@@ -31,7 +46,12 @@ const NavLinks = (props) => {
       <Link href="/fees">
         <a onClick={() => props.isMobile && props.closeMobileMenu()}>
           {props.isMobile && (
-            <img src="/LinkImages/fees.svg" height="18px" width="18px" />
+            <img
+              src="/LinkImages/fees.svg"
+              height="18px"
+              width="18px"
+              alt="Fees"
+            />
           )}
           FEES
         </a>

--- a/packages/ui/styles/Footer.module.css
+++ b/packages/ui/styles/Footer.module.css
@@ -1,20 +1,12 @@
+/* COMMON */
 .footer {
   margin-top: 0;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  transition: 0.5s;
 }
-
-.logo {
-  margin-left: 63px;
-  flex: auto;
-}
-
-.logo:hover {
-  cursor: pointer;
-}
-
 .syvita {
   margin-left: 75px;
   margin-right: 205px;
@@ -24,38 +16,28 @@
   font-size: 24px;
   line-height: 36px;
   letter-spacing: -0.01em;
-  color: #000000;
 }
-
-.syvita a {
-  color: #000000;
-}
-
-.syvita a:hover {
-  color: #9146ff;
-}
-
 .links {
   flex: auto;
   margin-right: 5px;
   font-family: Inter;
   font-style: normal;
   font-weight: bold;
-  color: #000000;
   text-decoration: none;
   font-size: 14px;
   line-height: 20px;
   letter-spacing: 0.1em;
 }
-
 .links a {
   padding: 0 24px;
-  color: #000000;
   text-decoration: none;
 }
-
-.links a:hover {
-  color: #9146ff;
+.logo {
+  margin-left: 63px;
+  flex: auto;
+}
+.logo:hover {
+  cursor: pointer;
 }
 
 @media (max-width: 1172px) {
@@ -72,7 +54,6 @@
   .links {
     margin: 0;
   }
-
   .links a {
     padding: 0 12px;
   }
@@ -81,3 +62,52 @@
     margin: 0;
   }
 }
+
+/* LIGHT MODE */
+
+.light .footer {
+  background-color: white;
+}
+.light .syvita a {
+  color: black;
+}
+.light .syvita {
+  color: black;
+}
+.light .links a {
+  color: black;
+}
+.light .syvita a:hover {
+  color: #9146ff;
+}
+.light .links a:hover {
+  color: #9146ff;
+}
+
+/* DARK MODE */
+
+.dark .footer {
+  background-color: black;
+}
+.dark .syvita a {
+  color:white;
+}
+.dark .syvita {
+  color: white;
+}
+.dark .links a{
+  color: white;
+}
+.dark .syvita a:hover {
+  color: #9146ff;
+}
+.dark .links a:hover {
+  color: #9146ff;
+}
+.dark .logo{
+  filter: invert(1)
+}
+
+/* WAIFU THEME?? */
+/* EASTER EGG #1 */
+/* EASTER EGG #2 */


### PR DESCRIPTION
Instead of adding a global dark style, each component is having its own (this'll make it a lot easier to customise). In this push I added the dark theme for the footer. The way this is set up allows us to add any additional themes we may want by just adding [.themeName] before the CSS selector in each component.  I reorganised the Footer CSS module to demonstrate what I mean.

To actually enable a component to use different themes, we need to import useContext and ThemeContext as shown in the changes in components/Footer.tsx. We can add this to the top level of a component when adding a dark mode for it.

<a href="https://gitpod.io/#https://github.com/syvita/sypool/pull/33"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

